### PR TITLE
Fixed invisible languages dropdown

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -321,33 +321,26 @@ ul.footer-menu li a:hover {
 	padding:  3px;
 }
 .styleSelect select {
-	background: transparent;
-	width: 120px;
-	padding: 0px;
+	background: #404142;
+	width: 100%;
+	padding: 5px 10px;
 	font-size: 16px;
-	line-height: 1;
-	border: 0;
-	border-radius: 0;
-	height: 25px;
+	border: none;
 	-webkit-appearance: none;
 	color: white;
-	margin: 0px;
 }
 
 .styleSelect {
-	width: 100px;
-	height: 25px;
+	width: 120px;
+	height: fit-content;
 	overflow: hidden;
 	border-radius: 10px;
-	background: #404142;
-	border: 0px;
 	margin-right: 125px;
-	padding-left: 18px;
 }
 .flag{
 	position: absolute;
 	background-color: #404142;
-	margin-top: 5px;
+	margin-top: 10px;
 	margin-right: 85px;
 	height: 25px;
 	width: 40px;


### PR DESCRIPTION
The dropdown had white text which wasn't visible. Fixed it and improved spacing.

Before:
![langDropdown](https://user-images.githubusercontent.com/40134655/77858063-c224d300-721e-11ea-817d-5ad54d1d56e5.jpg)

After:
![langDropdownFix](https://user-images.githubusercontent.com/40134655/77858071-ca7d0e00-721e-11ea-9a5b-4c32198e682f.jpg)

Please review @llaske.
