### PR TITLE
Improving UI of examples grid

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,6 +224,8 @@ a span.ti-twitter-alt {
 .activity-gallery {
 	display: flex;
 	flex-flow: row wrap;
+	justify-content: space-evenly;
+	align-items: stretch;
 }
 
 .header-area {
@@ -240,9 +242,15 @@ a span.ti-twitter-alt {
 	flex-flow: row;
 	flex-direction: column;
 	flex: 0 0 0%;
-	margin-left: 20px;
-	margin-right: 20px;
-	margin-bottom: 20px;
+	margin: 30px;
+}
+.activity-gallery-item .card-body {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+.activity-gallery-item .btn-red {
+	margin-top: auto;
 }
 
 .websites {


### PR DESCRIPTION
The grid of example activities with their demos is not centered which leaves unnecessary empty space on the right side. See here:

![examplesIssue](https://user-images.githubusercontent.com/40134655/78241682-6dbf7300-74fe-11ea-980a-b60628a5339f.jpg)

I have centered the grid and also made all Demo buttons aligned in a row. This gives a more uniform and professional look to this section.
Result:

![examplesFix](https://user-images.githubusercontent.com/40134655/78241782-97789a00-74fe-11ea-96cb-9200c4995edf.jpg)

Please review @llaske and let me know any changes required.