### PR TITLE
Added Examples menu and fixed Home scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,12 @@
 				</a>
 			</li>
 			<li>
+				<a href="#gallery" class="page-scroll">
+					<span data-l10n-id="menu-examples" class="menu-title">Examples</span>
+					<span class="dot"></span>
+				</a>
+			</li>
+			<li>
 				<a href="#apps" class="page-scroll">
 					<span data-l10n-id="menu-apps" class="menu-title">Download</span>
 					<span class="dot"></span>
@@ -62,7 +68,7 @@
 	<!-- End: Language Selector -->
 	<!-- Start: Header -->
 	<a name="home"></a>
-	<section class="header-area" style="background-image: url('img/background.jpg');">
+	<section id="home" class="header-area" style="background-image: url('img/background.jpg');">
 		<!-- Start: Language Selector -->
 		<div class="language" align="right">
 

--- a/locale.ini
+++ b/locale.ini
@@ -1,6 +1,7 @@
 [*]
 menu-home=Home
 menu-features=Features
+menu-examples=Examples
 menu-apps=Download
 menu-more=More
 head-taste=The leading learning platform for children
@@ -77,6 +78,7 @@ data-403-maintenance=Please check the URL in your browser address bar.
 [en]
 menu-home=Home
 menu-features=Features
+menu-examples=Examples
 menu-apps=Download
 menu-more=More
 head-taste=The leading learning platform for children
@@ -153,6 +155,7 @@ data-403-maintenance=Please check the URL in your browser address bar.
 [pl]
 menu-home=Główna
 menu-features=Pobierz
+menu-examples=Przykłady
 menu-apps=Aplikacje
 menu-more=Więcej
 head-taste=The leading learning platform for children
@@ -229,6 +232,7 @@ data-403-maintenance=Please check the URL in your browser address bar.
 [es]
 menu-home=Inicio
 menu-features=Features
+menu-examples=Ejemplos
 menu-apps=Descarga
 menu-more=Más
 head-taste=The leading learning platform for children
@@ -305,6 +309,7 @@ data-403-maintenance=Please check the URL in your browser address bar.
 [fr]
 menu-home=Accueil
 menu-features=Fonctionnalités
+menu-examples=Exemples
 menu-apps=Installer
 menu-more=Plus
 head-taste=La première plateforme éducative pour enfant
@@ -381,6 +386,7 @@ data-403-maintenance=Merci de vérifier l'URL dans la barre d'adresse de votre n
 [pt]
 menu-home=Início
 menu-features=Features
+menu-examples=Exemplos
 menu-apps=Baixar
 menu-more=Mais
 head-taste=The leading learning platform for children


### PR DESCRIPTION
Examples of Activities seems an important section missing from the side menu navigation.
Also, the home nav doesn't scroll smoothly to the top as there is no section with `id="home"`. See here:

![menuIssue](https://user-images.githubusercontent.com/40134655/78243786-00154600-7502-11ea-846c-3c6b8c7822a8.gif)

This PR adds the Examples nav and also fixes the home scroll issue.
Result:

![menuFix](https://user-images.githubusercontent.com/40134655/78384985-c70bcd00-75f8-11ea-934f-78896c560281.gif)

What are your thoughts @llaske?
