### PR TITLE
Changes to language of site main page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "ergonomic"
+    ]
+}

--- a/po/en.po
+++ b/po/en.po
@@ -90,8 +90,8 @@ msgstr "Server"
 
 #: content-server
 msgctxt "content-server"
-msgid "Sugarizer Server is the back-end for network features of Sugarizer. It provides a Web App so Sugarizer can be accessed using web browser from any device across the network, whether at home, in school or, if preferred, across the web. Sugarizer Server also provides collaborative functions between devices using either the installed App or Web App on the network."
-msgstr "Sugarizer Server is the back-end for network features of Sugarizer. It provides a Web App so Sugarizer can be accessed using web browser from any device across the network, whether at home, in school or, if preferred, across the web. Sugarizer Server also provides collaborative functions between devices using either the installed App or Web App on the network."
+msgid "Sugarizer Server is the back-end for all network features of Sugarizer. It provides a Web App so Sugarizer can be accessed using web browser from any device across the network, whether at home, in school or, if preferred, across the web. Sugarizer Server also provides collaborative functions between devices using either the installed App or Web App on the network."
+msgstr "Sugarizer Server is the back-end for all network features of Sugarizer. It provides a Web App so Sugarizer can be accessed using web browser from any device across the network, whether at home, in school or, if preferred, across the web. Sugarizer Server also provides collaborative functions between devices using either the installed App or Web App on the network."
 
 #: head-sugarizer
 msgctxt "head-sugarizer"
@@ -265,8 +265,8 @@ msgstr "Field approved"
 
 #: feature-approved
 msgctxt "feature-approved"
-msgid "The Sugarizer UI use ergonomic principles from Sugar platform, developed for the One Laptop per Child project and used every day by more than 2 million children around the world."
-msgstr "The Sugarizer UI use ergonomic principles from Sugar platform, developed for the One Laptop per Child project and used every day by more than 2 million children around the world."
+msgid "The Sugarizer UI uses ergonomic principles from Sugar platform, developed for the One Laptop per Child project and used every day by more than 2 million children around the world."
+msgstr "The Sugarizer UI uses ergonomic principles from Sugar platform, developed for the One Laptop per Child project and used every day by more than 2 million children around the world."
 
 #: headfeat-adblocker
 msgctxt "headfeat-adblocker"

--- a/po/en.po
+++ b/po/en.po
@@ -235,8 +235,8 @@ msgstr "Children focused"
 
 #: feature-children
 msgctxt "feature-children"
-msgid "Sugarizer was thought for children between 6 and 12. The unique Sugarizer UI is discoverable, wholly intuitive, and use metaphors usable by children who don't know how to read."
-msgstr "Sugarizer was thought for children between 6 and 12. The unique Sugarizer UI is discoverable, wholly intuitive, and use metaphors usable by children who don't know how to read."
+msgid "Sugarizer was built for learners between 6 and 12. The unique Sugarizer UI is discoverable, wholly intuitive, and uses metaphors even non-readers can understand."
+msgstr "Sugarizer was built for learners between 6 and 12. The unique Sugarizer UI is discoverable, wholly intuitive, and uses metaphors even non-readers can understand."
 
 #: headfeat-school
 msgctxt "headfeat-school"

--- a/po/en.po
+++ b/po/en.po
@@ -71,7 +71,7 @@ msgstr "Web App"
 #: content-web
 msgctxt "content-web"
 msgid "Sugarizer works on any device with a recent browser version. Sugarizer Web App doesn't need any installation on the device but requires a permanent access to a Sugarizer Server."
-msgstr "It could work on any device with a recent browser version. Sugarizer Web App doesn't need any installation on the device but requires a permanent access to a Sugarizer Server."
+msgstr "Sugarizer works on any device with a recent browser version. Sugarizer Web App doesn't need any installation on the device but requires a permanent access to a Sugarizer Server."
 
 #: head-app
 msgctxt "head-app"
@@ -245,8 +245,8 @@ msgstr "Learn at school and beyond"
 
 #: feature-school
 msgctxt "feature-school"
-msgid "Sugarizer provide a set of \"activities\", not a set of applications. This is more than a new naming convention"
-msgstr "Sugarizer provide a set of \"activities\", not a set of applications. This is more than a new naming convention"
+msgid "Sugarizer provides a set of \"activities\", not a set of applications. This is more than a new naming convention"
+msgstr "Sugarizer provides a set of \"activities\", not a set of applications. This is more than a new naming convention"
 
 #: headfeat-collaborative
 msgctxt "headfeat-collaborative"
@@ -275,8 +275,9 @@ msgstr "Ads Free"
 
 #: feature-adblocker
 msgctxt "feature-adblocker"
-msgid "95% of apps market for children in stores contain advertising! With Sugarizer you've got the guaranty to have 0% advertisement and 0% tracking tools included."
-msgstr "95% of apps market for children in stores contain advertising! With Sugarizer you've got the guaranty to have 0% advertisement and 0% tracking tools included."
+msgid "95% of apps market for children in stores contain advertising! With Sugarizer you're guaranteed to have  advertisements and 0 tracking tools included."
+msgstr "95% of apps market for children in stores contain advertising! With Sugarizer you're guaranteed to have  advertisements and 0 tracking tools included."
+
 
 #: headfeat-opensource
 msgctxt "headfeat-opensource"

--- a/po/en.po
+++ b/po/en.po
@@ -40,8 +40,8 @@ msgstr "The leading learning platform for children"
 
 #: head-children
 msgctxt "head-children"
-msgid "Sugarizer is a free/libre learning platform. The Sugarizer UI use ergonomic principles from Sugar platform, developed for the One Laptop per Child project and used every day by more than 2 million children around the world."
-msgstr "Sugarizer is a free/libre learning platform. The Sugarizer UI use ergonomic principles from Sugar platform, developed for the One Laptop per Child project and used every day by more than 2 million children around the world."
+msgid "Sugarizer is a free/libre learning platform. The Sugarizer UI uses ergonomic principles from Sugar platform, developed for the One Laptop per Child project and used every day by more than 2 million children around the world."
+msgstr "Sugarizer is a free/libre learning platform. The Sugarizer UI uses ergonomic principles from Sugar platform, developed for the One Laptop per Child project and used every day by more than 2 million children around the world."
 
 #: head-try
 msgctxt "head-try"
@@ -60,8 +60,8 @@ msgstr "Source code"
 
 #: content-components
 msgctxt "content-components"
-msgid "Sugarizer is distributed in the form of 3 components:"
-msgstr "Sugarizer is distributed in the form of 3 components:"
+msgid "Sugarizer can be used 3 ways:"
+msgstr "Sugarizer can be used 3 ways:"
 
 #: head-web
 msgctxt "head-web"
@@ -70,7 +70,7 @@ msgstr "Web App"
 
 #: content-web
 msgctxt "content-web"
-msgid "It could work on any device with a recent browser version. Sugarizer Web App doesn't need any installation on the device but requires a permanent access to a Sugarizer Server."
+msgid "Sugarizer works on any device with a recent browser version. Sugarizer Web App doesn't need any installation on the device but requires a permanent access to a Sugarizer Server."
 msgstr "It could work on any device with a recent browser version. Sugarizer Web App doesn't need any installation on the device but requires a permanent access to a Sugarizer Server."
 
 #: head-app
@@ -90,8 +90,8 @@ msgstr "Server"
 
 #: content-server
 msgctxt "content-server"
-msgid "Sugarizer Server is the back-end for network features of Sugarizer. It expose locally Web App so allow deployment of Sugarizer on a local server, for example on a school server. Sugarizer Server can also be used to provide collaboration features for App and Web App on the network."
-msgstr "Sugarizer Server is the back-end for network features of Sugarizer. It expose locally Web App so allow deployment of Sugarizer on a local server, for example on a school server. Sugarizer Server can also be used to provide collaboration features for App and Web App on the network."
+msgid "Sugarizer Server is the back-end for network features of Sugarizer. It provides a Web App so Sugarizer can be accessed using web browser from any device across the network, whether at home, in school or, if preferred, across the web. Sugarizer Server also provides collaborative functions between devices using either the installed App or Web App on the network."
+msgstr "Sugarizer Server is the back-end for network features of Sugarizer. It provides a Web App so Sugarizer can be accessed using web browser from any device across the network, whether at home, in school or, if preferred, across the web. Sugarizer Server also provides collaborative functions between devices using either the installed App or Web App on the network."
 
 #: head-sugarizer
 msgctxt "head-sugarizer"


### PR DESCRIPTION
I have edited the language on the site to clarify the purpose of Sugarizer.  Please feel free to accept or reject individually any of the changes as you see fit to do so.  I did not know how to refresh the contents of index.html from the configuration files, but I noticed the *.po files and locale.ini, and I will happily copy the changes over manually or run whatever command will generate the correct result, and then create a new PR.