### PR TITLE
fixed typo error and social icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,10 +506,14 @@
 				<span data-i18n="activities">Most activities use this license too but some could use a different license, check the README file for more.</span>
 			</p><br/>
             <p>&copy; 2013-<span id="currentYear"></span>, Lionel Laské, <a href="http://sugarlabs.org" title="Sugar Labs" target="_blank">Sugar Labs Inc.</a> and <a href="https://github.com/llaske/sugarizer/blob/dev/docs/credits.md" target="_blank">Contributors</a>.</p><br/>
+			<p>Connect with us on:</p>
+			<div class="d-flex flex-row justify-content-start">
 			<a href="https://github.com/llaske/sugarizer" target="_blank"><i class="fab fa-github-square fa-3x" style="margin-left:8px;margin-top:5px;color:#ffffff;"></i></a>
 			<a href="https://twitter.com/sugarizerapp" target="_blank"><i class="fab fa-square-x-twitter fa-3x" style="margin-left:8px;margin-top:5px;color:#ffffff;"></i></a>
 			<a href="https://www.facebook.com/Sugarizer" target="_blank"><i class="fab fa-facebook-square fa-3x" style="margin-left:8px;margin-top:5px;color:#ffffff;"></i></a>
 			<a href="https://sugarizer.org/discord" target="_blank" style="margin-left:12px;"><span class="position-absolute"><i class="fab fa-discord bg-white rounded-2 fa-2x align-self-center justify-content-center text-center" style="color: #2a2a2a; padding: .16em .1em; margin-bottom: 0.5rem; transform: translateY(7.9px) ;"></i></span></a>
+			</div>
+			
 		</div>
 		<div class="col-md-6 col-sm-6">
 			<p><span data-i18n="original">Original page design by:</span> <a href="https://piotr-antosz.pl"
@@ -572,7 +576,6 @@
 		document.getElementById("policyurl").href = "docs/articles/policy_" + lang + ".html";
 	}
 </script>
-/* Copy to clipboard */
 <script>
     function copyToClipboard(button, text) {
       navigator.clipboard.writeText(text).then(function() {

--- a/index.html
+++ b/index.html
@@ -506,14 +506,10 @@
 				<span data-i18n="activities">Most activities use this license too but some could use a different license, check the README file for more.</span>
 			</p><br/>
             <p>&copy; 2013-<span id="currentYear"></span>, Lionel Laské, <a href="http://sugarlabs.org" title="Sugar Labs" target="_blank">Sugar Labs Inc.</a> and <a href="https://github.com/llaske/sugarizer/blob/dev/docs/credits.md" target="_blank">Contributors</a>.</p><br/>
-			
-			<div class="d-flex flex-row justify-content-start">
 			<a href="https://github.com/llaske/sugarizer" target="_blank"><i class="fab fa-github-square fa-3x" style="margin-left:8px;margin-top:5px;color:#ffffff;"></i></a>
 			<a href="https://twitter.com/sugarizerapp" target="_blank"><i class="fab fa-square-x-twitter fa-3x" style="margin-left:8px;margin-top:5px;color:#ffffff;"></i></a>
 			<a href="https://www.facebook.com/Sugarizer" target="_blank"><i class="fab fa-facebook-square fa-3x" style="margin-left:8px;margin-top:5px;color:#ffffff;"></i></a>
 			<a href="https://sugarizer.org/discord" target="_blank" style="margin-left:12px;"><span class="position-absolute"><i class="fab fa-discord bg-white rounded-2 fa-2x align-self-center justify-content-center text-center" style="color: #2a2a2a; padding: .16em .1em; margin-bottom: 0.5rem; transform: translateY(7.9px) ;"></i></span></a>
-			</div>
-			
 		</div>
 		<div class="col-md-6 col-sm-6">
 			<p><span data-i18n="original">Original page design by:</span> <a href="https://piotr-antosz.pl"

--- a/index.html
+++ b/index.html
@@ -506,7 +506,7 @@
 				<span data-i18n="activities">Most activities use this license too but some could use a different license, check the README file for more.</span>
 			</p><br/>
             <p>&copy; 2013-<span id="currentYear"></span>, Lionel Laské, <a href="http://sugarlabs.org" title="Sugar Labs" target="_blank">Sugar Labs Inc.</a> and <a href="https://github.com/llaske/sugarizer/blob/dev/docs/credits.md" target="_blank">Contributors</a>.</p><br/>
-			<p>Connect with us on:</p>
+			
 			<div class="d-flex flex-row justify-content-start">
 			<a href="https://github.com/llaske/sugarizer" target="_blank"><i class="fab fa-github-square fa-3x" style="margin-left:8px;margin-top:5px;color:#ffffff;"></i></a>
 			<a href="https://twitter.com/sugarizerapp" target="_blank"><i class="fab fa-square-x-twitter fa-3x" style="margin-left:8px;margin-top:5px;color:#ffffff;"></i></a>

--- a/locales/en.json
+++ b/locales/en.json
@@ -36,7 +36,7 @@
 	"mailing": "Donate",
 	"mailing-content": "Do you like Sugarizer? Donate to help us make it accessible to more users.",
 	"oss": "Sugarizer is a free software under",
-	"licence": "Apache 2 licence",
+	"licence": "Apache 2 license",
 	"code": "source code is available on GitHub",
 	"here": "here",
 	"activities": "Most activities use this license too but some could use a different license, check the README file for more.",


### PR DESCRIPTION
Hii @llaske,

i fixed "licence" typo error to "license" in en.json by changing "licence" key-value pair and I made small UI change to social icons that looks better than before. could you please review this pr. #57 
![image](https://github.com/user-attachments/assets/ede51a8c-c6de-4202-823a-7c2e160dce25)

Thank you!